### PR TITLE
Change logging directory names to use ISO8601 dates

### DIFF
--- a/lib/constants.py
+++ b/lib/constants.py
@@ -5,4 +5,4 @@ FINDMY_FILES = [
 NAME_SEPARATOR = '_'
 NULL_STR = 'NULL'
 TIME_FORMAT = '%m/%d/%Y, %H:%M:%S'
-DATE_FORMAT = '%m-%d-%Y'
+DATE_FORMAT = '%Y-%m-%d'


### PR DESCRIPTION
Better to have logging directory names in ISO8601 date format (%Y-%m-%d) so that they naturally sort properly